### PR TITLE
Add ingore-weight annotation to kuberos ingress

### DIFF
--- a/templates/kuberos.yaml.tpl
+++ b/templates/kuberos.yaml.tpl
@@ -8,6 +8,7 @@ ingress:
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: "100"
     external-dns.alpha.kubernetes.io/set-identifier: "dns-${clusterName}"
+    cloud-platform.justice.gov.uk/ignore-external-dns-weight: "true"
   host: "${hostname}"
   tls:
     - host:


### PR DESCRIPTION
This add ingore-weight annotation so the OPA ignores these ingress for checking the identifier format. This ingress is cluster specific and wont have a weighted policy.
