### PR TITLE
update-pin-helm-version-in-modules

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -11,7 +11,7 @@ jobs:
         ref: ${{ github.event.pull_request.head.ref }}
 
     - name: Render terraform docs and push changes back to PR
-      uses: terraform-docs/gh-actions@v0.6.0
+      uses: terraform-docs/gh-actions@v0.11.0
       with:
         working-dir: .
         output-file: README.md

--- a/README.md
+++ b/README.md
@@ -15,43 +15,45 @@ See the [examples/](examples/) folder.
 
 | Name | Version |
 |------|---------|
-| terraform | >= 0.14 |
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.14 |
+| <a name="requirement_helm"></a> [helm](#requirement\_helm) | ~> 2.6.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| helm | n/a |
-| kubernetes | n/a |
+| <a name="provider_helm"></a> [helm](#provider\_helm) | ~> 2.6.0 |
+| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | n/a |
 
 ## Modules
 
-No Modules.
+No modules.
 
 ## Resources
 
-| Name |
-|------|
-| [helm_release](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) |
-| [kubernetes_ingress_v1](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1) |
-| [kubernetes_limit_range](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/limit_range) |
-| [kubernetes_namespace](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) |
-| [kubernetes_network_policy](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) |
-| [kubernetes_resource_quota](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/resource_quota) |
+| Name | Type |
+|------|------|
+| [helm_release.kuberos](https://registry.terraform.io/providers/hashicorp/helm/latest/docs/resources/release) | resource |
+| [kubernetes_ingress_v1.ingress_redirect_kuberos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/ingress_v1) | resource |
+| [kubernetes_limit_range.kuberos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/limit_range) | resource |
+| [kubernetes_namespace.kuberos](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/namespace) | resource |
+| [kubernetes_network_policy.allow_ingress_controllers](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_network_policy.default](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/network_policy) | resource |
+| [kubernetes_resource_quota.namespace_quota](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/resource_quota) | resource |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| cluster\_address | The cluster address - used by kuberos | `any` | n/a | yes |
-| cluster\_domain\_name | The cluster domain - used by kuberos | `any` | n/a | yes |
-| oidc\_issuer\_url | Issuer URL used to authenticate to kuberos | `any` | n/a | yes |
-| oidc\_kubernetes\_client\_id | OIDC ClientID used to authenticate to kuberos | `any` | n/a | yes |
-| oidc\_kubernetes\_client\_secret | OIDC ClientSecret used to authenticate to kuberos | `any` | n/a | yes |
+| <a name="input_cluster_address"></a> [cluster\_address](#input\_cluster\_address) | The cluster address - used by kuberos | `any` | n/a | yes |
+| <a name="input_cluster_domain_name"></a> [cluster\_domain\_name](#input\_cluster\_domain\_name) | The cluster domain - used by kuberos | `any` | n/a | yes |
+| <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | Issuer URL used to authenticate to kuberos | `any` | n/a | yes |
+| <a name="input_oidc_kubernetes_client_id"></a> [oidc\_kubernetes\_client\_id](#input\_oidc\_kubernetes\_client\_id) | OIDC ClientID used to authenticate to kuberos | `any` | n/a | yes |
+| <a name="input_oidc_kubernetes_client_secret"></a> [oidc\_kubernetes\_client\_secret](#input\_oidc\_kubernetes\_client\_secret) | OIDC ClientSecret used to authenticate to kuberos | `any` | n/a | yes |
 
 ## Outputs
 
-No output.
+No outputs.
 
 <!--- END_TF_DOCS --->
 

--- a/versions.tf
+++ b/versions.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     helm = {
       source = "hashicorp/helm"
+      version = "~> 2.6.0"
     }
     kubernetes = {
       source = "hashicorp/kubernetes"


### PR DESCRIPTION
Why: 
[upgrade & pin Helm provider for Infrastructure#3882](https://app.zenhub.com/workspaces/cloud-platform-team-5ccb0b8a81f66118c983c189/issues/ministryofjustice/cloud-platform/3882)