### PR TITLE
Bump kuberos chart to 0.3.9

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -40,7 +40,7 @@ resource "helm_release" "kuberos" {
   chart         = "kuberos"
   repository    = "https://ministryofjustice.github.io/cloud-platform-helm-charts"
   recreate_pods = true
-  version       = "0.3.8"
+  version       = "0.3.9"
 
   values = [templatefile("${path.module}/templates/kuberos.yaml.tpl", {
     hostname = terraform.workspace == local.live_workspace ? format("%s.%s", "login", local.live_domain) : format(


### PR DESCRIPTION
Release: https://github.com/ministryofjustice/cloud-platform-kuberos/releases/tag/2.4