### PR TITLE
Parameterise image tag as input

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_cluster_address"></a> [cluster\_address](#input\_cluster\_address) | The cluster address - used by kuberos | `any` | n/a | yes |
 | <a name="input_cluster_domain_name"></a> [cluster\_domain\_name](#input\_cluster\_domain\_name) | The cluster domain - used by kuberos | `any` | n/a | yes |
+| <a name="input_image_tag"></a> [image\_tag](#input\_image\_tag) | The image tag to use for the kuberos deployment | `any` | n/a | yes |
 | <a name="input_oidc_issuer_url"></a> [oidc\_issuer\_url](#input\_oidc\_issuer\_url) | Issuer URL used to authenticate to kuberos | `any` | n/a | yes |
 | <a name="input_oidc_kubernetes_client_id"></a> [oidc\_kubernetes\_client\_id](#input\_oidc\_kubernetes\_client\_id) | OIDC ClientID used to authenticate to kuberos | `any` | n/a | yes |
 | <a name="input_oidc_kubernetes_client_secret"></a> [oidc\_kubernetes\_client\_secret](#input\_oidc\_kubernetes\_client\_secret) | OIDC ClientSecret used to authenticate to kuberos | `any` | n/a | yes |

--- a/examples/main.tf
+++ b/examples/main.tf
@@ -14,5 +14,6 @@ module "kuberos" {
   cluster_address = "https://test"
   # cluster_address               = data.terraform_remote_state.cluster.outputs.cluster_endpoint
 
+  image_tag = "0.4.0"
   # depends_on = [module.ingress_controllers]
 }

--- a/main.tf
+++ b/main.tf
@@ -54,7 +54,7 @@ resource "helm_release" "kuberos" {
     issuer_url      = var.oidc_issuer_url
     replicaCount    = 2
     clusterName     = terraform.workspace
-    image_tag      = var.image_tag
+    image_tag       = var.image_tag
   })]
 
   set_sensitive {

--- a/main.tf
+++ b/main.tf
@@ -54,6 +54,7 @@ resource "helm_release" "kuberos" {
     issuer_url      = var.oidc_issuer_url
     replicaCount    = 2
     clusterName     = terraform.workspace
+    image_tag      = var.image_tag
   })]
 
   set_sensitive {

--- a/templates/kuberos.yaml.tpl
+++ b/templates/kuberos.yaml.tpl
@@ -4,6 +4,9 @@
 
 replicaCount: "${replicaCount}"
 
+image:
+  tag: "${image_tag}"
+
 ingress:
   annotations:
     external-dns.alpha.kubernetes.io/aws-weight: "100"

--- a/variables.tf
+++ b/variables.tf
@@ -17,3 +17,7 @@ variable "oidc_kubernetes_client_secret" {
 variable "oidc_issuer_url" {
   description = "Issuer URL used to authenticate to kuberos"
 }
+
+variable "image_tag" {
+  description = "The image tag to use for the kuberos deployment"
+}


### PR DESCRIPTION
This PR 
- adds a input image_tag to the helm release so the image_tag can be configurable. 
- Set the image tag from 2.6.0 to 2.7.0

Without this image_tag input, the helm chart default value has to be changed everytime a new image is being released. 
This is usually fine as a general approach of embedding image into the helm chart defaults, but having to change the helm chart everytime for patch changes is jumping too many loops to get to the infrastructure.
